### PR TITLE
Update unit.py

### DIFF
--- a/src/entities/unit.py
+++ b/src/entities/unit.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 import math
 import random
 from collections import deque
-from typing import TYPE_CHECKING, Callable, Deque, Iterable, List, Optional, Tuple
+from typing import TYPE_CHECKING, Callable, Deque, Iterable, List, Optional, Tuple, Dict, Any
 
 import pygame
 
@@ -22,10 +22,10 @@ UNIT_INNER_CIRCLE_RATIO = settings.UNIT_INNER_CIRCLE_RATIO
 # Optional settings with sensible fallbacks (no changes required in your settings.py)
 try:
     from src.utils.settings import (
-        UNIT_HOVER_COLOR,       # e.g. (240, 220, 80)
-        UNIT_HEALTHBAR_BG,      # e.g. (20, 20, 20)
-        UNIT_HEALTHBAR_FG,      # e.g. (80, 220, 80)
-        UNIT_SELECTION_RING_WIDTH,  # e.g. 2
+        UNIT_HOVER_COLOR,            # e.g. (240, 220, 80)
+        UNIT_HEALTHBAR_BG,           # e.g. (20, 20, 20)
+        UNIT_HEALTHBAR_FG,           # e.g. (80, 220, 80)
+        UNIT_SELECTION_RING_WIDTH,   # e.g. 2
     )
 except Exception:
     UNIT_HOVER_COLOR = (240, 220, 80)
@@ -109,10 +109,22 @@ class Unit:
         self.facing_angle = 0.0  # radians, derived from motion
         self.is_paused: bool = False
 
+        # Optional arrival smoothing (0 disables; non-zero radius slows on approach)
+        self.arrive_slowdown_radius_px: float = 0.0  # NEW: default keeps old behavior
+
+        # Temporary speed boost (handled in update)
+        self._speed_boost_time: float = 0.0          # NEW
+        self._speed_boost_mult: float = 1.0          # NEW
+
         # Health (optional UI)
         self.max_hp = 100
         self.hp = 100
         self.show_health_bar = False
+        self._health_bar_timer: float = 0.0          # NEW: auto-hide timer
+
+        # Visual feedback
+        self._flash_time: float = 0.0                # NEW: quick highlight timer
+        self._flash_color: Tuple[int, int, int] = (255, 255, 255)
 
         # Callbacks (optional)
         self.on_reach_tile: Optional[Callable[[Unit, Tuple[int, int]], None]] = None
@@ -131,17 +143,47 @@ class Unit:
 
     def set_path(self, path: List[Tuple[int, int]], *, append: bool = False) -> None:
         """Sets a new path (tile list). If append=True, queue after existing."""
+        if not path:
+            return
+
+        # Drop duplicate consecutive tiles and an initial current-tile waypoint
+        cleaned: List[Tuple[int, int]] = []
+        prev = None
+        cur_tile = (int(self.tile_pos.x), int(self.tile_pos.y))
+        for t in path:
+            if prev is None or t != prev:
+                if not cleaned and t == cur_tile and not append:
+                    # Skip an immediate 'start-at-current' tile
+                    prev = t
+                    continue
+                cleaned.append(t)
+                prev = t
+
+        if not cleaned:
+            return
+
         if not append:
-            self.path = list(path)
+            self.path = list(cleaned)
             self._waypoints_px.clear()
         else:
-            self.path.extend(path)
+            self.path.extend(cleaned)
 
-        for t in path:
+        for t in cleaned:
             self._waypoints_px.append(_tile_to_world_center(t))
 
         if self._waypoints_px and (self.target_world_pos is None or self._arrived(self.target_world_pos)):
             self.target_world_pos = self._waypoints_px[0].copy()
+
+    def append_waypoint(self, tile_xy: Tuple[int, int]) -> None:
+        """NEW: Append a single tile waypoint to the end of the current path."""
+        self.set_path([tile_xy], append=True)
+
+    def insert_waypoint_front(self, tile_xy: Tuple[int, int]) -> None:
+        """NEW: Insert a waypoint as the next immediate target (front of the queue)."""
+        wp = _tile_to_world_center(tile_xy)
+        self.path.insert(0, tile_xy)
+        self._waypoints_px.appendleft(wp)
+        self.target_world_pos = wp.copy()
 
     def clear_path(self) -> None:
         """Stops movement."""
@@ -176,11 +218,121 @@ class Unit:
         d = _shortest_delta(self.world_pos, pygame.Vector2(world_point), w_px, h_px)
         return d.length()
 
+    def look_at(self, world_point: Tuple[float, float]) -> None:
+        """NEW: Manually set facing toward a world point (without moving)."""
+        v = pygame.Vector2(world_point) - self.world_pos
+        if v.length_squared() > 0:
+            self.facing_angle = math.atan2(v.y, v.x)
+
+    def set_speed_boost(self, multiplier: float, duration: float) -> None:
+        """NEW: Temporarily boost (or reduce) speed by `multiplier` for `duration` seconds."""
+        self._speed_boost_mult = max(0.0, float(multiplier))
+        self._speed_boost_time = max(0.0, float(duration))
+
+    def apply_damage(self, amount: int, *, show_bar: bool = True) -> bool:
+        """NEW: Apply damage, optionally revealing the health bar briefly. Returns True if unit 'dies'."""
+        amt = max(0, int(amount))
+        if amt <= 0:
+            return False
+        self.hp = max(0, self.hp - amt)
+        if show_bar:
+            self.show_health_bar = True
+            self._health_bar_timer = max(self._health_bar_timer, 2.0)  # keep visible for at least 2s
+        # Quick flash feedback
+        self.flash((255, 120, 120), duration=0.12)
+        return self.hp <= 0
+
+    def heal(self, amount: int, *, show_bar: bool = True) -> None:
+        """NEW: Heal the unit (clamped to max_hp)."""
+        amt = max(0, int(amount))
+        if amt <= 0:
+            return
+        self.hp = min(self.max_hp, self.hp + amt)
+        if show_bar:
+            self.show_health_bar = True
+            self._health_bar_timer = max(self._health_bar_timer, 1.6)
+        self.flash((120, 220, 120), duration=0.10)
+
+    def predict_time_to_reach_tile(self, tile_xy: Tuple[int, int], map_w_tiles: int, map_h_tiles: int) -> float:
+        """
+        NEW: Predict time (seconds) to reach a given tile.
+        Uses queued waypoints + straight-line to the requested tile at current effective speed.
+        Returns math.inf if speed is zero.
+        """
+        map_w_px = map_w_tiles * TILE_SIZE
+        map_h_px = map_h_tiles * TILE_SIZE
+
+        # Build a pixel-position sequence starting from the current world position
+        positions: List[pygame.Vector2] = [self.world_pos.copy()]
+        positions.extend(list(self._waypoints_px))
+        positions.append(_tile_to_world_center(tile_xy))
+
+        # Sum toroidal segment distances
+        dist_px = 0.0
+        for i in range(len(positions) - 1):
+            dist_px += _shortest_delta(positions[i], positions[i + 1], map_w_px, map_h_px).length()
+
+        effective_mult = self.speed_mult * (self._speed_boost_mult if self._speed_boost_time > 0 else 1.0)
+        speed_px_per_sec = max(0.0, self.speed_tiles_per_sec * TILE_SIZE * effective_mult)
+        return math.inf if speed_px_per_sec <= 0 else dist_px / speed_px_per_sec
+
+    def to_dict(self) -> Dict[str, Any]:
+        """NEW: Serialize minimal state for savegames/debug."""
+        return {
+            "tile_pos": (int(self.tile_pos.x), int(self.tile_pos.y)),
+            "world_pos": (float(self.world_pos.x), float(self.world_pos.y)),
+            "speed_tiles_per_sec": self.speed_tiles_per_sec,
+            "radius_px": self.radius_px,
+            "color": tuple(self.color),
+            "speed_mult": self.speed_mult,
+            "hp": self.hp,
+            "max_hp": self.max_hp,
+            "path": list(self.path),
+        }
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> Unit:
+        """NEW: Deserialize a unit from a dict produced by to_dict()."""
+        u = cls(
+            tuple(data.get("tile_pos", (0, 0))),
+            speed_tiles_per_sec=float(data.get("speed_tiles_per_sec", UNIT_MOVES_PER_SECOND)),
+            radius_px=float(data.get("radius_px", UNIT_RADIUS)),
+            color=tuple(data.get("color", UNIT_COLOR)),
+        )
+        # Restore world pos if provided
+        wp = data.get("world_pos")
+        if wp:
+            u.world_pos = pygame.Vector2(float(wp[0]), float(wp[1]))
+            u.target_world_pos = u.world_pos.copy()
+        u.speed_mult = float(data.get("speed_mult", 1.0))
+        u.max_hp = int(data.get("max_hp", 100))
+        u.hp = int(data.get("hp", u.max_hp))
+        # Restore path
+        pth = data.get("path") or []
+        if pth:
+            u.set_path(list(map(tuple, pth)), append=False)
+        return u
+
+    def flash(self, color: Tuple[int, int, int], duration: float = 0.12) -> None:
+        """NEW: Brief visual highlight (light ring) to signal hits/heals/selection."""
+        self._flash_color = color
+        self._flash_time = max(self._flash_time, float(duration))
+
     # ---------- update ----------
     def update(self, dt: float, map_width_tiles: int, map_height_tiles: int) -> None:
         """Moves smoothly along waypoints; handles toroidal wrapping."""
         if self.is_paused or dt <= 0:
             return
+
+        # Tick timers
+        if self._speed_boost_time > 0.0:
+            self._speed_boost_time = max(0.0, self._speed_boost_time - dt)
+        if self._health_bar_timer > 0.0:
+            self._health_bar_timer = max(0.0, self._health_bar_timer - dt)
+            if self._health_bar_timer == 0.0:
+                self.show_health_bar = False
+        if self._flash_time > 0.0:
+            self._flash_time = max(0.0, self._flash_time - dt)
 
         map_w_px = map_width_tiles * TILE_SIZE
         map_h_px = map_height_tiles * TILE_SIZE
@@ -210,9 +362,18 @@ class Unit:
             return
 
         # Move toward current target
-        speed_px_per_sec = max(0.0, self.speed_tiles_per_sec * TILE_SIZE) * max(0.0, self.speed_mult)
+        effective_mult = self.speed_mult * (self._speed_boost_mult if self._speed_boost_time > 0 else 1.0)
+        base_speed = max(0.0, self.speed_tiles_per_sec * TILE_SIZE)
+        speed_px_per_sec = base_speed * max(0.0, effective_mult)
+
         to_target = _shortest_delta(self.world_pos, self._waypoints_px[0], map_w_px, map_h_px)
         dist = to_target.length()
+
+        # Optional 'arrive' smoothing near waypoint
+        if self.arrive_slowdown_radius_px > 0.0 and dist < self.arrive_slowdown_radius_px and dist > _EPS:
+            # Scale speed smoothly in [0.35, 1.0] to prevent visible snaps
+            k = max(0.35, dist / self.arrive_slowdown_radius_px)
+            speed_px_per_sec *= k
 
         if dist <= max(self.arrival_epsilon_px, speed_px_per_sec * dt):
             # Snap to target this frame
@@ -263,11 +424,7 @@ class Unit:
 
         # Selection/hover ring (underlay)
         if self.selected or self.hovered:
-            # The selection ring width is now constant to prevent a "flickering"
-            # or "pulsing" effect that was distracting.
             ring_w = UNIT_SELECTION_RING_WIDTH
-            # The unit should always use the global, theme-aware setting for its
-            # selection color, rather than storing its own copy.
             ring_color = settings.UNIT_SELECTED_COLOR if self.selected else UNIT_HOVER_COLOR
             pygame.draw.circle(surface, ring_color, screen_pos, int(radius * 1.15), int(max(1, ring_w)))
 
@@ -281,6 +438,10 @@ class Unit:
         ny = math.sin(self.facing_angle)
         tip = pygame.Vector2(screen_pos.x + nx * (radius * 0.8), screen_pos.y + ny * (radius * 0.8))
         pygame.draw.line(surface, (0, 0, 0), screen_pos, tip, 2)
+
+        # Flash ring (quick feedback)
+        if self._flash_time > 0.0:
+            pygame.draw.circle(surface, self._flash_color, screen_pos, int(radius * 1.25), 2)
 
         # Health bar (optional)
         if self.show_health_bar and self.max_hp > 0:


### PR DESCRIPTION
New functions & capabilities

append_waypoint(tile_xy) – quickly extend the current path with one tile.

insert_waypoint_front(tile_xy) – insert a waypoint as the next target without clearing the existing queue.

look_at(world_point) – manually set facing direction without movement.

set_speed_boost(multiplier, duration) – temporary speed modifier; handled each update().

apply_damage(amount, *, show_bar=True) / heal(amount, *, show_bar=True) – HP management with auto health‑bar reveal and brief visual flash; returns True from apply_damage if the unit “dies”.

predict_time_to_reach_tile(tile_xy, map_w_tiles, map_h_tiles) – estimate travel time (seconds) using queued waypoints and current effective speed.

to_dict() / from_dict() – lightweight serialization/deserialization for saves or debugging.

flash(color, duration=0.12) – quick ring highlight to signal hits/heals/selection feedback.

Quality & UX improvements (backwards‑compatible)

Path sanitation in set_path(): removes duplicate consecutive tiles and drops a redundant initial “current tile” waypoint (when not appending).

Optional arrival smoothing via arrive_slowdown_radius_px (default 0.0 to preserve original behavior). If set, the unit eases into waypoints to avoid snapping.

Temporary speed boosts are factored into movement seamlessly (no change unless a boost is active).

Auto‑hide health bar using an internal timer after damage/heal events.

Visual feedback: brief, inexpensive flash ring on hits/heals.

Maintained all existing public methods and signatures; defaults preserve original movement and rendering.