### PR TITLE
Update effects.py

### DIFF
--- a/src/entities/effects.py
+++ b/src/entities/effects.py
@@ -1,3 +1,21 @@
+diff --git a/src/entities/effects.py b/src/entities/effects.py
+--- a/src/entities/effects.py
++++ b/src/entities/effects.py
+@@
++from __future__ import annotations
++
++# Make the 'Unit' name available to linters/type-checkers without
++# creating a runtime dependency (avoids circular imports).
++from typing import TYPE_CHECKING, Any
++
++if TYPE_CHECKING:
++    # Imported only for static analysis; not executed at runtime.
++    from src.entities.unit import Unit  # noqa: F401
++else:
++    # At runtime, annotations are postponed (see __future__ above),
++    # but some linters still want 'Unit' to be a real name.
++    Unit = Any  # type: ignore[assignment,misc]
+
 """
 Status/visual effects for Units: speed boosts, stuns, dots, flashes, etc.
 """


### PR DESCRIPTION
Why this fixes Issue #49

The build output shows multiple F821 errors for Unit used in annotations inside effects.py. Those happen when the name isn’t visible to the linter at import time (even if you used a string annotation) or when the tooling environment evaluates annotations statically. By:

Postponing evaluation of annotations via from __future__ import annotations, and

Exposing a safe Unit symbol for static analysis only (if TYPE_CHECKING: from src.entities.unit import Unit) while providing an Any fallback at runtime,

we eliminate the undefined-name condition without causing circular imports. This pattern is standard for cross‑referencing types between modules in Python 3.8–3.11 projects and plays well with Flake8/Pyflakes and MyPy.