### PR TITLE
Create event_bus.py

### DIFF
--- a/src/utils/event_bus.py
+++ b/src/utils/event_bus.py
@@ -1,0 +1,32 @@
+# c:/prj/WorldDom/src/utils/event_bus.py
+from __future__ import annotations
+from typing import Any, Callable, DefaultDict, Dict, List
+from collections import defaultdict
+
+
+class EventBus:
+    """
+    Ultra-light pub/sub bus:
+        off = bus.on("toast", lambda payload: ...)
+        bus.emit("toast", text="Hello")
+        off()  # unsubscribe
+    """
+    def __init__(self) -> None:
+        self._subs: DefaultDict[str, List[Callable[[Dict[str, Any]], None]]] = defaultdict(list)
+
+    def on(self, event: str, handler: Callable[[Dict[str, Any]], None]) -> Callable[[], None]:
+        self._subs[event].append(handler)
+        def off() -> None:
+            try:
+                self._subs[event].remove(handler)
+            except ValueError:
+                pass
+        return off
+
+    def emit(self, event: str, **payload: Any) -> None:
+        for h in list(self._subs.get(event, ())):
+            h(payload)
+
+
+# shared instance
+bus = EventBus()


### PR DESCRIPTION
EventBus (src/utils/event_bus.py)

Tiny pub/sub utility to decouple systems. Any module can emit() a toast or other in‑game events without needing to import your Game class.

Example: your DebugPanel can call bus.emit("toast", text="New Map Generated").